### PR TITLE
added more blocks to protect with LWC

### DIFF
--- a/src/main/java/com/griefcraft/lwc/LWC.java
+++ b/src/main/java/com/griefcraft/lwc/LWC.java
@@ -1752,6 +1752,10 @@ public class LWC {
             name = "furnace";
         }
 
+        if (name.contains("diode")) {
+            name = "diode";
+        }
+
         if (name.endsWith("_")) {
             name = name.substring(0, name.length() - 1);
         }

--- a/src/main/resources/core.yml
+++ b/src/main/resources/core.yml
@@ -125,10 +125,28 @@ protections:
             autoRegister: private
         wooden_door:
             enabled: true
-        iron_door:
-            enabled: true
+            autoRegister: off
         trap_door:
             enabled: true
+            autoRegister: off
+        cake:
+            enabled: true
+            autoRegister: off
+        note:
+            enabled: true
+            autoRegister: off
+        jukebox:
+            enabled: true
+            autoRegister: off
+        diode:
+            enabled: true
+            autoRegister: off
+        stone_button:
+            enabled: true
+            autoRegister: off
+        lever:
+            enabled: true
+            autoRegister: off
 
 modes:
     droptransfer:


### PR DESCRIPTION
This should add the following blocks as protectable:
cake, noteblock, jukebox, repeater, button, lever